### PR TITLE
Bugfix in forces and topologies

### DIFF
--- a/HiRE_lib/mod_excludedV.f90
+++ b/HiRE_lib/mod_excludedV.f90
@@ -28,7 +28,7 @@ MODULE MOD_EXCLV
          INTEGER, INTENT(IN) :: I, J                   !indices of grains
          INTEGER, INTENT(IN) :: TI,TJ                  !type of grains
          REAL(KIND = REAL64), INTENT(IN) :: X(NOPT)    !input coordinates
-         REAL(KIND = REAL64), INTENT(OUT) :: F(NOPT)   !force
+         REAL(KIND = REAL64), INTENT(INOUT) :: F(NOPT) !force
          REAL(KIND = REAL64), INTENT(OUT) :: EEXCL     !energy contribution
          REAL(KIND = REAL64), INTENT(IN) :: DA2        !input squared distance between particles
          REAL(KIND = REAL64), INTENT(IN) :: DCORR      !correction for neighbouring nucleotides
@@ -48,7 +48,7 @@ MODULE MOD_EXCLV
 
          D = ((CT2-S)/DA)
 
-         EEXCL = DCORR*D**VPOWER
+         EEXCL = EXCLV_SCALING*(DCORR*D**VPOWER)
          DF = VPOWER*EEXCL/DA2
 
          F(3*I-2:3*I) = F(3*I-2:3*I) + DF*DX(1:3)

--- a/HiRE_lib/mod_hbonds.f90
+++ b/HiRE_lib/mod_hbonds.f90
@@ -483,60 +483,6 @@ MODULE MOD_HBONDS
 !                endif
 !             end do
 
-            fa(:,3) = fa(:,3)  - Ehb*(p/anga) * (&
-   !                   d anga / d ma0
-            salpa*(crossproduct(ua0, crossproduct(ra0-sina*ma0, ua0)))/dma &
-   !                   d anga / d ra0
-            -(crossproduct(ralpa-ra0*anga, ua)*dot_product(-rba, na0)/dna)/dra)
-
-            fa(:,2) = fa(:,2)        - Ehb*(p/anga)* (&
-   !                   d anga / d ua0
-            -calpa*(ra0- ua0*cosa)/dua & !
-   !                   d anga / d ma0
-            -salpa*( crossproduct(ua0, crossproduct(ra0-sina*ma0, ua0)) + &
-            crossproduct(va, crossproduct(ua, ra0-sina*ma0)) + &
-            crossproduct(ra0-sina*ma0, na) )/dma &
-   !                   d anga / d ra0
-            -(crossproduct(ua-va, ralpa-ra0*anga)*dot_product(-rba, na0)/dna)/dra)
-
-            fa(:,1) = fa(:,1) - Ehb*(p/anga)* (&
-   !                   d anga / d ua0
-            calpa*(ra0- ua0*cosa)/dua +&
-   !                   d anga / d ma0
-            salpa*(crossproduct(va, crossproduct(ua, ra0-sina*ma0)) + &
-            crossproduct(ra0-sina*ma0, na))/dma &
-   !                   d anga / d ra0
-            -(ralpa-ra0*anga+crossproduct(va, ralpa-ra0*anga)*dot_product(-rba, na0)/dna)/dra)&
-   !                   d angb / d rb0
-            - Ehb*(p/angb)*(ralpb-rb0*angb)/drb
-
-            fb(:,1) = fb(:,1)  - Ehb*(p/angb)* (&
-   !                   d angb / d ub0
-            calpb*(rb0- ub0*cosb)/dub +&
-   !                   d angb / d mb0
-            salpb*(crossproduct(vb, crossproduct(ub, rb0-sinb*mb0)) + &
-            crossproduct(rb0-sinb*mb0, nb))/dmb &
-   !                   d angb / d rb0
-            -(ralpb-rb0*angb+crossproduct(vb, ralpb-rb0*angb)*dot_product(rba, nb0)/dnb)/drb)&
-   !                   d anga / d ra0
-            - Ehb*(p/anga)*(ralpa-ra0*anga)/dra
-
-            fb(:,2) = fb(:,2)       - Ehb*(p/angb)* (&
-   !                   d angb / d ub0
-            -calpb*(rb0- ub0*cosb)/dub &
-   !                   d angb / d mb0
-            -salpb*( crossproduct(ub0, crossproduct(rb0-sinb*mb0, ub0)) + &
-            crossproduct(vb, crossproduct(ub, rb0-sinb*mb0)) + &
-            crossproduct(rb0-sinb*mb0, nb) )/dmb & !
-   !                   d angb / d rb0
-            -(crossproduct(ub-vb, ralpb-rb0*angb)*dot_product(rba, nb0)/dnb)/drb)
-
-            fb(:,3) = fb(:,3)        - Ehb*(p/angb)* (&
-   !                   d angb / d mb0
-            salpb*(crossproduct(ub0, crossproduct(rb0-sinb*mb0, ub0)))/dmb &
-   !                   d angb / d rb0
-            -(crossproduct(ralpb-rb0*angb, ub)*dot_product(rba, nb0)/dnb)/drb)
-
         ENDDO
         IF (EHHB .GE. REGCUT) RETURN      !! TEST HB EXISTANCE 06-04-2012
          HBEXIST = .TRUE.

--- a/Top4HiRE/src/CG_data_creation.f90
+++ b/Top4HiRE/src/CG_data_creation.f90
@@ -163,7 +163,13 @@ MODULE CG_DATA
                CGTYPE(ATOMCOUNTER) = 2
                CGMASS(ATOMCOUNTER) = 16.000D0
                CGCHARGE(ATOMCOUNTER) = 0.000D0
-               !third grain differs between RNA and DNA!
+               !third grain: O3
+               ATOMCOUNTER = ATOMCOUNTER + 1
+               CGNAMES(ATOMCOUNTER) = "O3"
+               CGTYPE(ATOMCOUNTER) = 1
+               CGMASS(ATOMCOUNTER) = 16.000D0
+               CGCHARGE(ATOMCOUNTER) = 0.000D0
+               !fourth grain differs between RNA and DNA!
                ATOMCOUNTER = ATOMCOUNTER + 1
                IF (RESTYPE(J).EQ.0) THEN !RNA
                   !third grain: R4
@@ -176,13 +182,7 @@ MODULE CG_DATA
                END IF
                CGMASS(ATOMCOUNTER) = 20.000D0
                CGCHARGE(ATOMCOUNTER) = 0.000D0 
-               !fourth grain: O3
-               ATOMCOUNTER = ATOMCOUNTER + 1
-               CGNAMES(ATOMCOUNTER) = "O3"
-               CGTYPE(ATOMCOUNTER) = 1
-               CGMASS(ATOMCOUNTER) = 16.000D0
-               CGCHARGE(ATOMCOUNTER) = 0.000D0
-               !fifth grai also differs between RNA and DNA
+               !fifth grain also differs between RNA and DNA
                ATOMCOUNTER = ATOMCOUNTER + 1
                IF (RESTYPE(J).EQ.0) THEN !RNA
                   !fourth grain: R1


### PR DESCRIPTION
# Forces
We noticed a mismatch between the numerical and analytical gradients reported by using the `CHECKD` flag when running GMIN.

The culprit seemed to be several lines from an older version of the HBonds forces calculation that were still lingering in the `HBNEW` subroutine. After removing these lines, the `CHECKD` gradients now match.

While debugging, I also noticed that the excluded volume energy/force was not taking into account the `EXCLV_SCALING` parameter, so I added it.

# Topology
I also noticed a "conceptual bug" related to the new topology generation. Consider that the planes used for stacking and HBonds are obtained from the last 3 beads for every residue. In the case of pyrimidines, we want these beads to be `...-R4-R1-U1/C1` (as used to be in the old topology format).

However, the order of beads in the new topology was `P-O5-R4-O3-R1-X1`. This means that the code was considering the beads `O3-R1-X1` instead for the planes. I didn't find any other subroutine expecting the `O3` in such position, so I swapped the order of the beads to `P-O5-O3-R4-R1-X1` to obtain the expected planes.